### PR TITLE
optimize row output

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,6 @@ module.exports = postcss.plugin('postcss-simple-grid', function (opts) {
 				var rowValue = decl.value;
 
 				decl.parent.append({
-					prop: 'display', value: 'block'
-				});
-				decl.parent.append({
 					prop: 'margin', value: '0 auto'
 				});
 				decl.parent.append({
@@ -37,9 +34,6 @@ module.exports = postcss.plugin('postcss-simple-grid', function (opts) {
 				});
 				decl.parent.append({
 					prop: 'position', value: 'relative'
-				});
-				decl.parent.append({
-					prop: 'width', value: '100%'
 				});
 
 				css.insertAfter(decl.parent ,(selectorName + ':before,' + selectorName + ':after { content: " "; display: table; }' + selectorName + ':after { clear: both; }'));


### PR DESCRIPTION
Hey Eduárd! I noticed that the create-row declaration outputs both display: block and width: 100%. We might be able to optimize this a little further by assuming that any row is going to be a block level element.

Just a thought, let me know what you think!